### PR TITLE
[#44] Provide basic CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - 3.5
+
+install:
+   - pip install -U tox
+
+script:
+  - make test-all

--- a/dezentrale_web/apps/blog/models.py
+++ b/dezentrale_web/apps/blog/models.py
@@ -1,8 +1,8 @@
 from django.db import models
-from wagtail.wagtailcore.models import Page
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, StreamFieldPanel
-from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore import blocks
+from wagtail.wagtailcore.fields import StreamField
+from wagtail.wagtailcore.models import Page
 
 
 class BlogIndexPage(Page):

--- a/dezentrale_web/apps/events/admin.py
+++ b/dezentrale_web/apps/events/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/dezentrale_web/apps/events/models.py
+++ b/dezentrale_web/apps/events/models.py
@@ -1,7 +1,6 @@
 from django.db import models
-
-from wagtail.wagtailcore.models import Page
 from wagtail.wagtailadmin.edit_handlers import FieldPanel
+from wagtail.wagtailcore.models import Page
 
 
 class EventsIndexPage(Page):

--- a/dezentrale_web/apps/events/tests.py
+++ b/dezentrale_web/apps/events/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/dezentrale_web/apps/events/views.py
+++ b/dezentrale_web/apps/events/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/dezentrale_web/apps/wagtail_search/views.py
+++ b/dezentrale_web/apps/wagtail_search/views.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, unicode_literals
 
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.shortcuts import render
-
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailsearch.models import Query
 

--- a/dezentrale_web/config/urls.py
+++ b/dezentrale_web/config/urls.py
@@ -3,11 +3,9 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
-
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
-
 
 urlpatterns = [
     url(r'^grappelli/', include('grappelli.urls')),

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ max-line-length = 99
 line_length = 99
 not_skip = __init__.py
 known_first_party = dezentrale_web,tests
-known_third_party = braces,configurations,coverage,crispy_forms,dj_database_url,django,envdir,factory,factory_boy,faker,fauxfactory,freezegun,grappelli,psycopg2,pytest,pytest_factoryboy,six
+known_third_party = braces,configurations,coverage,crispy_forms,dj_database_url,django,envdir,factory,factory_boy,faker,fauxfactory,freezegun,grappelli,psycopg2,pytest,pytest_factoryboy,six, wagtail
 skip = manage.py,migrations,wsgi.py
 
 [pep257]

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py27,py35,flake8,isort,manifest,docs,pep257
+envlist = flake8,isort,manifest
+#isort,manifest,docs,pep257
 minversion = 2.1.0
 
 [testenv]
-install_command = pip install -c requirements/constraints.pip {opts} {packages}
+install_command = pip install {opts} {packages}
 commands =
-    pip install -c requirements/constraints.pip -r requirements/test.pip
+    pip install -r requirements/test.pip
     make coverage
 passenv =
     DEFAULT_DATABASE_URL
@@ -14,7 +15,7 @@ passenv =
 whitelist_externals = make
 
 [testenv:flake8]
-basepython = python3.5
+basepython = python3
 commands =
     flake8 setup.py dezentrale_web/ tests/
 deps =
@@ -25,7 +26,7 @@ deps =
 skip_install = True
 
 [testenv:isort]
-basepython = python3.5
+basepython = python3
 commands =
     isort --check-only --recursive --verbose setup.py dezentrale_web/ tests/
 deps =
@@ -33,7 +34,7 @@ deps =
 skip_install = True
 
 [testenv:manifest]
-basepython = python3.5
+basepython = python3
 commands =
     check-manifest -v
 deps =
@@ -41,17 +42,17 @@ deps =
 skip_install = True
 
 [testenv:pep257]
-basepython = python3.5
+basepython = python3
 commands =
-    {toxinidir}/pep257.sh
+    pep257 setup.py dezentrale_web/ tests/
 deps =
     pep257==0.7.0
 skip_install = True
 
 [testenv:docs]
-basepython = python3.5
+basepython = python3
 commands =
-    pip install -c requirements/constraints.pip -r requirements/docs.pip
+    pip install -r requirements/docs.pip
     make docs BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_BUILD:'-W'}
     make -C docs linkcheck BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_LINKCHECK:}
     doc8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = flake8,isort,manifest
-#isort,manifest,docs,pep257
 minversion = 2.1.0
 
 [testenv]


### PR DESCRIPTION
This PR introduces basic CI with travis-ci.
For now we just run the following tox targets:

- ``flake8``
- ``isort``
- ``manifest``

In particular, we currently do not perform any actual code tests nor do we run ``docs`` and ``pep257``. Those will have to be added at a later time.

Closes: #44